### PR TITLE
Fix `session not found` error at startup when `base-index` is set

### DIFF
--- a/tmuxomatic
+++ b/tmuxomatic
@@ -988,7 +988,7 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name ):
 	layout = {} # Indexed by line
 	panes_w = 0
 	panes_h = 0
-	focus_window = 1 # Windows in tmux are 1+
+	focus_window_name = None # Use window name rather than window index so base-index option is honoured if set for tmux config
 	line = "" # Loaded line stored here
 	scale___existing_window_table = []
 
@@ -1242,7 +1242,7 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name ):
 				print("(2) Pane definition: " + line)
 			if command_matches(line, "foc"):
 				# Window focus
-				focus_window = window_number
+				focus_window_name = window_name
 				continue # Next line
 			if command_matches(line[:3], "dir"):
 				# Default directory
@@ -1460,7 +1460,8 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name ):
 	#
 	# Set default window
 	#
-	list_build.append( EXE + " select-window -t " + str(focus_window - 1) ) # Windows are 0+ in tmux
+	if focus_window_name is not None:
+		list_build.append( EXE + " select-window -t " + focus_window_name )
 
 	#
 	# Notify user that tmux execution will begin and allow for time to break (ARGS.verbose >= 1)


### PR DESCRIPTION
TL;DR - use window name to set focus rather than window index

In my ~/.tmux.conf I have `set -g base-index 1` so window numbers are 1-offset instead of 0-offset (this makes switching to a window easier using the number row on the keyboard).

However, tmuxomatic was displaying `session not found` error when starting up with this tmux config option set.

The problem is that tmuxomatic assumed that windows were 0-offset, and trying to go to the window index based on that.

So use the window name to focus the window instead of the index
