### PR TITLE
Make tmuxomatic run on tmux >= 2.5 and phyton 3

### DIFF
--- a/tmuxomatic
+++ b/tmuxomatic
@@ -777,8 +777,12 @@ class SessionFile(object):
         self.Load_Shorthand_SharedCore( bol )
     def Load(self):
         # Load raw data
+        if sys.version_info < (3, ):
+            mode = "rU"
+        else:  # python 3 deprecates mode "U" in favor of "newline" option
+            mode = "r"
         rawfile = ""
-        f = open(self.filename, "rU")
+        f = open(self.filename, mode)
         while True:
             line = f.readline()
             if not line: break # EOF

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -2090,7 +2090,6 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # There are two ways to fix this.  1) Add "set-option -g allow-rename off" to your ".tmux.conf".
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").
                     # Here we automatically do method 1 for the user, unless the user requests otherwise.
-                    list_build.append( "set-option -t " + session_name + " quiet on" )
                     renaming = [ "off", "on" ][ARGS.renaming]
                     list_build.append( "set-option -t " + session_name + " allow-rename " + renaming )
                     list_build.append( "set-option -t " + session_name + " automatic-rename " + renaming )

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -512,6 +512,9 @@ def signal_handler_hup( signal_number, frame ):
     _ = repr(signal_number) + repr(frame) # Satisfies pylint
     raise KeyboardInterrupt
 
+def support_quiet_option(version):
+    return float(version) < 2.5
+
 def satisfies_minimum_version(minimum, version):
     """
     Asserts compliance by tmux version.  I've since seen a similar version check somewhere that may come with Python
@@ -2090,6 +2093,9 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # There are two ways to fix this.  1) Add "set-option -g allow-rename off" to your ".tmux.conf".
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").
                     # Here we automatically do method 1 for the user, unless the user requests otherwise.
+
+                    if support_quiet_option(tmux_version()[1]):
+                        list_build.append( "set-option -t " + session_name + " quiet on" )
                     renaming = [ "off", "on" ][ARGS.renaming]
                     list_build.append( "set-option -t " + session_name + " allow-rename " + renaming )
                     list_build.append( "set-option -t " + session_name + " automatic-rename " + renaming )


### PR DESCRIPTION
Based on PR #22. 
Remove deprecation warning when tmuxomatic is installed on python 3.4