### PR TITLE
Make tmuxomatic run on tmux >= 2.5 and phyton 3. Correct pane resize on tmux >= 2.6

### DIFF
--- a/tmuxomatic
+++ b/tmuxomatic
@@ -515,6 +515,15 @@ def signal_handler_hup( signal_number, frame ):
 def support_quiet_option(version):
     return float(version) < 2.5
 
+def new_session_dimensions_args(tmux_version, user_w, user_h):
+    if float(tmux_version) <= 2.5:
+        return ''                                           # Tmux 2.5 use user screen as default windowsize
+    if float(tmux_version) < 2.8:
+        return "-x " + str(user_w) + " -y " + str(user_h)   # Tmux 2.6 use 80x24 window for detached sessions
+
+    return "-x - -y -"                                      # tmux 2.8 add '-' argument to use users screen as default window size
+
+
 def satisfies_minimum_version(minimum, version):
     """
     Asserts compliance by tmux version.  I've since seen a similar version check somewhere that may come with Python
@@ -2092,7 +2101,7 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # The shell's cwd must be set, the only other way to do this is to discard the
                     # window that is automatically created when calling "new-session".
                     cwd_execution = ("cd " + list_panes_dir) if list_panes_dir else ""
-                    list_build.append( "new-session -d -s " + session_name + " -n \"" + window_name + "\"" )
+                    list_build.append( "new-session -d -s " + session_name + " -n \"" + window_name + "\" " + new_session_dimensions_args(USERS_TMUX, user_wh[0], user_wh[1]) )
                     # Normally, tmux automatically renames windows based on whatever is running in the focused pane.
                     # There are two ways to fix this.  1) Add "set-option -g allow-rename off" to your ".tmux.conf".
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -777,8 +777,12 @@ class SessionFile(object):
         self.Load_Shorthand_SharedCore( bol )
     def Load(self):
         # Load raw data
+        if sys.version_info < (3, ):
+            mode = "rU"
+        else:  # python 3 deprecates mode "U" in favor of "newline" option
+            mode = "r"
         rawfile = ""
-        f = open(self.filename, "rU")
+        f = open(self.filename, mode)
         while True:
             line = f.readline()
             if not line: break # EOF

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -2090,7 +2090,6 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # There are two ways to fix this.  1) Add "set-option -g allow-rename off" to your ".tmux.conf".
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").
                     # Here we automatically do method 1 for the user, unless the user requests otherwise.
-                    list_build.append( "set-option -t " + session_name + " quiet on" )
                     renaming = [ "off", "on" ][ARGS.renaming]
                     list_build.append( "set-option -t " + session_name + " allow-rename " + renaming )
                     list_build.append( "set-option -t " + session_name + " automatic-rename " + renaming )

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -512,6 +512,9 @@ def signal_handler_hup( signal_number, frame ):
     _ = repr(signal_number) + repr(frame) # Satisfies pylint
     raise KeyboardInterrupt
 
+def support_quiet_option(version):
+    return float(version) < 2.5
+
 def satisfies_minimum_version(minimum, version):
     """
     Asserts compliance by tmux version.  I've since seen a similar version check somewhere that may come with Python
@@ -2090,6 +2093,9 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # There are two ways to fix this.  1) Add "set-option -g allow-rename off" to your ".tmux.conf".
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").
                     # Here we automatically do method 1 for the user, unless the user requests otherwise.
+
+                    if support_quiet_option(tmux_version()[1]):
+                        list_build.append( "set-option -t " + session_name + " quiet on" )
                     renaming = [ "off", "on" ][ARGS.renaming]
                     list_build.append( "set-option -t " + session_name + " allow-rename " + renaming )
                     list_build.append( "set-option -t " + session_name + " automatic-rename " + renaming )

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -2107,7 +2107,7 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
                     # 2) Add "export DISABLE_AUTO_TITLE=true" to your shell's run commands file (e.g., ".bashrc").
                     # Here we automatically do method 1 for the user, unless the user requests otherwise.
 
-                    if support_quiet_option(tmux_version()[1]):
+                    if support_quiet_option(USERS_TMUX):
                         list_build.append( "set-option -t " + session_name + " quiet on" )
                     renaming = [ "off", "on" ][ARGS.renaming]
                     list_build.append( "set-option -t " + session_name + " allow-rename " + renaming )


### PR DESCRIPTION
Based on PR #25.
Acording to (tmux 2.6 changelog)[https://github.com/tmux/tmux/blob/master/CHANGES#L414]: 

```
All new sessions that are unattached (whether with -d or started with no terminal) 
are now created with size 80 x 24
```

So it's mandatory to specify dimension when new-session is called.

Tmux 2.8 add `-x - -y -` args to use user screen dimensions